### PR TITLE
Customize Force Layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
 			</div>
 			<div class="fl w-100">
 				<button class="f6 link dim br3 ph3 pv2 mb2 dib white gradient" id="calculate" type="button"
-					data-loading-text="Calculating..." autocomplete="off">Calculate <i class="em em-tada" aria-role="presentation" aria-label="PARTY POPPER"></i></button>
+					data-loading-text="Calculating..." autocomplete="off">Navigate <i class="em em-telescope" aria-role="presentation" aria-label="TELESCOPE"></i></button>
 			</div>
 		</form>
 		</div>

--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
 	<script type="text/javascript" src="js/jquery.csv.min.js"></script>
 	<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.22/b-1.6.5/b-html5-1.6.5/datatables.min.js"></script>
 	</script>
-	<script type="text/javascript" src="js/jscolor.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.4.2/jscolor.min.js"></script>
 	<script>
 	    function updateColor(picker) {
 	        d3.selectAll('.node').attr('fill', picker.toString());

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
 						<div id="customize-form">
 							<div id="force-layout" class="flex flex-column" style="display: none;">
 								<h1 class="f6 lh-copy">Customize Force Layout Graph</h1>
-								<div class="fl w-100 f6 mid-gray h2">
+								<div class="fl w-100 f6 mid-gray pv2">
 									<label for="centrality">Size by centrality:</label>
 									<select name="centrality" id="centrality">
 										<option value="degree">Degree</option>
@@ -158,11 +158,15 @@
 										<option value="eigenvector">Eigenvector</option>
 									</select>
 								</div>
-								<div class="fl w-100 f6 mid-gray h2">
+								<div class="fl w-100 f6 mid-gray pv2">
+									<label for="color-picker">Choose a node color:</label>
+									<input name="color-picker" id="color-picker" data-jscolor="{onInput:'updateColor(this)'}" value='08B3E5' />
+								</div>
+								<div class="fl w-100 f6 mid-gray pv2">
 							 		<label for="edge-weight">Include edge weights?</label>
 									<input name="edge-weight" id="edge-weight" type="checkbox" checked />
 								</div>
-								<div class="fl w-100 f6 mid-gray h2">
+								<div class="fl w-100 f6 mid-gray pv2">
 							 		<input type="radio" value="straight" name="lineType" id="straight" checked>
 							 		<label for="straight">Straight Lines</label>
 							 		<input type="radio" value="curved" name="lineType" id="curved">
@@ -249,6 +253,15 @@
 	<script type="text/javascript" src="js/jquery.csv.min.js"></script>
 	<script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.22/b-1.6.5/b-html5-1.6.5/datatables.min.js"></script>
 	</script>
+	<script type="text/javascript" src="js/jscolor.js"></script>
+	<script>
+	    function updateColor(picker) {
+	        d3.selectAll('.node').attr('fill', picker.toString());
+            }
+
+            jscolor.trigger('input');
+	</script>
+
 	<script type='module' src='js/main.js'></script>
 
 </body>

--- a/js/forceLayout.js
+++ b/js/forceLayout.js
@@ -40,6 +40,7 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
                     // Restore nodes and links to normal opacity.
                     d3.selectAll('.edge').style('opacity', '1');
                     d3.selectAll('.node').style('opacity', '1');
+                    d3.selectAll('.nodeLabel').style('opacity', '1');
 	});
 
     var container = svg.append('g')
@@ -93,6 +94,8 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
 	.classed("node", true)
         .attr("r", d => d[`radius_${centrality}`])
         .attr("fill", $('#color-picker').val())
+	.attr("stroke", "white")
+	.attr("stroke-width", 2)
         .on('click', function(d, i) {
                     // Ternary operator restyles links and nodes if they are adjacent.
                     d3.selectAll('.edge').style('opacity', function (l) {
@@ -101,7 +104,11 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
                     d3.selectAll('.node').style('opacity', function (n) {
               	      return neighboring(d, n) ? 1 : 0.1;
                     });
+                    d3.selectAll('.nodeLabel').style('opacity', function (n) {
+              	      return neighboring(d, n) ? 1 : 0.1;
+                    });
                     d3.select(this).style('opacity', 1);
+		    d3.select(`#node${nodeList.indexOf(d)}`).style('opacity', 1);
         })
         .on("dblclick", releasenode)
         .call(d3.drag()
@@ -115,6 +122,8 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
         .data(nodeList)
         .enter().append("text")
         .text(d => d.id)
+	.classed("nodeLabel", true)
+	.attr("id", d => `node${nodeList.indexOf(d)}`)
         .attr('dx', d => d[`radius_${centrality}`] + 5)
         .attr('dy', 3)
         .style('font-size', d => d[`fontSize_${centrality}`]);

--- a/js/forceLayout.js
+++ b/js/forceLayout.js
@@ -29,6 +29,9 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
         .attr("viewBox", "0 0 1400 1000")
         .classed("svg-content-responsive", true);
 
+    // Call zoom for svg container.
+    svg.call(d3.zoom().on('zoom', zoomed));
+
     svg.append('rect')
 	.attr('width', '100%')
 	.attr('height', '100%')
@@ -38,6 +41,7 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
                     d3.selectAll('.edge').style('opacity', '1');
                     d3.selectAll('.node').style('opacity', '1');
 	});
+
     var container = svg.append('g')
         .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
     
@@ -162,6 +166,11 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
     function releasenode(d) {
         d.fx = null;
         d.fy = null;
+    }
+
+    // Zooming function translates the size of the svg container.
+    function zoomed() {
+    	  container.attr("transform", "translate(" + d3.event.transform.x + ", " + d3.event.transform.y + ") scale(" + d3.event.transform.k + ")");
     }
 
         // A dropdown menu with three different centrality measures, calculated in NetworkX.

--- a/js/forceLayout.js
+++ b/js/forceLayout.js
@@ -29,7 +29,7 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
     var simulation = d3.forceSimulation()
         .force("link", d3.forceLink().id(d => d.id).distance(100).strength(1))
         .force('charge', d3.forceManyBody().strength(-1000))
-        .force('collide', d3.forceCollide(18).iterations(16))
+        .force('collide', d3.forceCollide().radius(d => d[`radius_${centrality}`]))
         .force("center", d3.forceCenter(width / 2, height / 2))
         .force('y', d3.forceY(0))
         .force('x', d3.forceX(0));
@@ -138,8 +138,8 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
             node.attr('r', d => d[`radius_${centrality}`]);
             nodeLabel.attr('font-size', d => d[`fontSize_${centrality}`]);
 			// Recalculate collision detection based on selected centrality.
-//			simulation.force("collide", d3.forceCollide().radius( function (d) { return centralitySize(d[centrality]); }));
-//			simulation.alphaTarget(0.1).restart();
+			simulation.force("collide", d3.forceCollide().radius( function (d) { return d[`radius_${centrality}`]; }));
+			simulation.alpha(1).restart();
 	});
 	d3.select('#edge-weight').on('change', function() {
         link.attr("stroke-width", d => this.checked ? d.scaled_weight / 2: 3)

--- a/js/forceLayout.js
+++ b/js/forceLayout.js
@@ -92,7 +92,7 @@ export function drawForceLayout(edgeList, nodeList, colorValues, graphType, grap
         .enter().append("circle")
 	.classed("node", true)
         .attr("r", d => d[`radius_${centrality}`])
-        .attr("fill", d => color(d.community))
+        .attr("fill", $('#color-picker').val())
         .on('click', function(d, i) {
                     // Ternary operator restyles links and nodes if they are adjacent.
                     d3.selectAll('.edge').style('opacity', function (l) {


### PR DESCRIPTION
An early Christmas present for Network Navigator! No rush on these, @ZoeLeBlanc; we can review them and merge after the holidays.

This branch includes all the rest of the customizations for the Force Layout:

- collision detection
- scroll to zoom
- click to highlight node neighborhoods (and click anywhere to de-highlight)
- custom node color picker!

The extra good news is that once we're satisfied with these, we can easily copy them over to finish the arc diagram too. (But I figure we'll do that in a separate PR.)

![](https://media.giphy.com/media/l2YWluoNgk342F3k4/giphy.gif)
